### PR TITLE
Implement basic TurnEngine CLI

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,4 @@
+from .models import Tile, Agent
+from .turnloop import TurnEngine
+
+__all__ = ["Tile", "Agent", "TurnEngine"]

--- a/engine/models.py
+++ b/engine/models.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+@dataclass
+class Tile:
+    x: int
+    y: int
+    walkable: bool = True
+    door: bool = False
+
+@dataclass
+class Agent:
+    id: str
+    x: int
+    y: int
+    hp: int = 100
+    hunger: int = 0
+    anger: int = 0
+    morale: int = 50
+    fatigue: int = 0
+    stress: int = 0

--- a/engine/turnloop.py
+++ b/engine/turnloop.py
@@ -1,0 +1,7 @@
+class TurnEngine:
+    def __init__(self, turns: int = 10):
+        self.turns = turns
+
+    def run_dummy(self):
+        for i in range(self.turns):
+            yield f"Turn {i + 1}: dummy event"

--- a/lucidity/cli.py
+++ b/lucidity/cli.py
@@ -1,0 +1,25 @@
+import argparse
+from engine.turnloop import TurnEngine
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog='lucidity')
+    subparsers = parser.add_subparsers(dest='command')
+
+    start_parser = subparsers.add_parser('start', help='Start the simulation')
+    start_parser.add_argument('--dummy', action='store_true', help='Run in dummy mode')
+    start_parser.add_argument('--turns', type=int, default=10, help='Number of turns to run')
+
+    args = parser.parse_args(argv)
+
+    if args.command == 'start':
+        if args.dummy:
+            engine = TurnEngine(turns=args.turns)
+            for event in engine.run_dummy():
+                print(event)
+        else:
+            raise NotImplementedError('Game logic not implemented yet')
+    else:
+        parser.print_help()
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lucidity"
+version = "0.1.0"
+description = "Turn-based simulation game"
+readme = "PRD.md"
+requires-python = ">=3.8"
+
+[project.scripts]
+lucidity = "lucidity.cli:main"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,8 @@
+from lucidity.cli import main
+
+
+def test_start_dummy(capsys):
+    main(['start', '--dummy', '--turns', '10'])
+    output = capsys.readouterr().out.strip().splitlines()
+    assert len(output) == 10
+    assert output[0].startswith('Turn 1')


### PR DESCRIPTION
## Summary
- start Sprint 1 from PRD: add Tile/Agent dataclasses and a dummy TurnLoop
- implement `lucidity` CLI that prints dummy events
- add simple unit test
- add `pyproject.toml` with console entry point

## Testing
- `pytest -q`
- `python -m lucidity.cli start --dummy --turns 5`


------
https://chatgpt.com/codex/tasks/task_e_6841086220e08330822c082ecdee2ef3