### PR TITLE
Add license and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing to Project Lucidity
+
+Thanks for your interest in contributing! We welcome issues and pull requests.
+
+## Issues
+
+If you find a bug or have a feature request, please open an issue on GitHub and provide as much detail as possible.
+
+## Pull Requests
+
+1. Fork the repository and create a new branch.
+2. Make your changes and add tests if applicable.
+3. Ensure `pytest` and any linters run successfully.
+4. Open a pull request against the `main` branch and describe your changes.
+
+We will review your contribution as soon as possible. Thank you!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Project Lucidity contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- add standard MIT license
- outline how to contribute in CONTRIBUTING.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841061d0e3c8330ad2a623dd752f844