### PR TITLE
Add replay command and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,19 @@ poetry install
 Start a new game with the default map and GPT-4o as the LLM model:
 
 ```bash
-lucidity start --map=default.json --agents=9 --model=gpt-4o
+lucidity start --map=default.json --agents=9 --model=gpt-4o --log session.db
 ```
 
 Replay a saved session:
 
 ```bash
-lucidity replay 2025-06-12T10-45-00
+lucidity replay session.db
+```
+
+Replay and stream over WebSocket:
+
+```bash
+lucidity replay session.db --ws
 ```
 
 For an all-in-one setup via Docker:

--- a/TEST_RESULTS.md
+++ b/TEST_RESULTS.md
@@ -1,0 +1,9 @@
+# Test Results
+
+All tests pass successfully.
+
+```
+pytest -q
+.......                                                                  [100%]
+7 passed, 1 warning in 0.24s
+```

--- a/lucidity/cli.py
+++ b/lucidity/cli.py
@@ -1,5 +1,15 @@
 import argparse
+import sqlite3
 from engine.turnloop import TurnEngine
+
+
+def _open_db(path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS events (id INTEGER PRIMARY KEY AUTOINCREMENT, message TEXT)"
+    )
+    return conn
 
 def main(argv=None):
     parser = argparse.ArgumentParser(prog='lucidity')
@@ -8,16 +18,44 @@ def main(argv=None):
     start_parser = subparsers.add_parser('start', help='Start the simulation')
     start_parser.add_argument('--dummy', action='store_true', help='Run in dummy mode')
     start_parser.add_argument('--turns', type=int, default=10, help='Number of turns to run')
+    start_parser.add_argument('--log', type=str, help='Path to SQLite log file')
+
+    replay_parser = subparsers.add_parser('replay', help='Replay a saved session')
+    replay_parser.add_argument('log', help='Path to SQLite log file')
+    replay_parser.add_argument('--ws', action='store_true', help='Serve events over WebSocket')
 
     args = parser.parse_args(argv)
 
     if args.command == 'start':
         if args.dummy:
             engine = TurnEngine(turns=args.turns)
-            for event in engine.run_dummy():
-                print(event)
+            db = None
+            if args.log:
+                db = _open_db(args.log)
+            try:
+                for event in engine.run_dummy():
+                    print(event)
+                    if db:
+                        db.execute("INSERT INTO events (message) VALUES (?)", (event,))
+                        db.commit()
+            finally:
+                if db:
+                    db.close()
         else:
             raise NotImplementedError('Game logic not implemented yet')
+    elif args.command == 'replay':
+        if args.ws:
+            from lucidity.ws import create_replay_app
+            import uvicorn
+
+            app = create_replay_app(args.log)
+            uvicorn.run(app, host='127.0.0.1', port=8000, log_level='warning')
+        else:
+            db = _open_db(args.log)
+            cursor = db.execute("SELECT message FROM events ORDER BY id")
+            for (message,) in cursor.fetchall():
+                print(message)
+            db.close()
     else:
         parser.print_help()
 

--- a/lucidity/ws.py
+++ b/lucidity/ws.py
@@ -1,0 +1,20 @@
+import sqlite3
+from fastapi import FastAPI, WebSocket
+
+
+def create_replay_app(log_path: str) -> FastAPI:
+    """Return a FastAPI app that streams events from a log file."""
+    app = FastAPI()
+
+    @app.websocket("/ws")
+    async def replay_ws(ws: WebSocket):
+        await ws.accept()
+        db = sqlite3.connect(log_path)
+        cursor = db.execute("SELECT message FROM events ORDER BY id")
+        for (message,) in cursor.fetchall():
+            await ws.send_text(message)
+        await ws.close()
+        db.close()
+
+    return app
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,3 +6,36 @@ def test_start_dummy(capsys):
     output = capsys.readouterr().out.strip().splitlines()
     assert len(output) == 10
     assert output[0].startswith('Turn 1')
+
+
+def test_replay_dummy(tmp_path, capsys):
+    log_file = tmp_path / 'session.db'
+    main(['start', '--dummy', '--turns', '3', '--log', str(log_file)])
+    start_output = capsys.readouterr().out.strip().splitlines()
+    assert len(start_output) == 3
+
+    main(['replay', str(log_file)])
+    replay_output = capsys.readouterr().out.strip().splitlines()
+    assert replay_output == start_output
+
+
+def test_replay_websocket(tmp_path, capsys):
+    log_file = tmp_path / 'session.db'
+    main(['start', '--dummy', '--turns', '2', '--log', str(log_file)])
+    start_output = capsys.readouterr().out.strip().splitlines()
+
+    from starlette.testclient import TestClient
+    from starlette.websockets import WebSocketDisconnect
+    from lucidity.ws import create_replay_app
+
+    app = create_replay_app(str(log_file))
+    client = TestClient(app)
+    with client.websocket_connect('/ws') as ws:
+        received = []
+        try:
+            while True:
+                received.append(ws.receive_text())
+        except WebSocketDisconnect:
+            pass
+
+    assert received == start_output


### PR DESCRIPTION
## Summary
- implement `--log` option for `lucidity start`
- add `replay` subcommand to replay a saved log
- document usage in README
- test replay functionality
- **new**: add WebSocket replay server

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68410e654f4483308c40ed8a007f8cb4